### PR TITLE
chore: add venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ instance/
 .webassets-cache/
 
 .DS_Store
+venv/


### PR DESCRIPTION
FIX: #4 
Adds `venv/` to `.gitignore` to prevent committing local Python virtual environments.
Virtual environments contain installed dependencies and OS-specific binaries that should not be tracked in the repository.