### PR TITLE
fix: ignore Python virtual environments (#4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ instance/
 .webassets-cache/
 
 .DS_Store
+# Virtual environments
+venv/
+env/
+.venv/


### PR DESCRIPTION
## Summary

Added venv directories to .gitignore:
- venv/
- env/
- .venv/

Fixes #4

**PrimeFix Tech**