### PR TITLE
Add sentiment analysis API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ instance/
 .webassets-cache/
 
 .DS_Store
+
+venv/

--- a/ML/sentiment_analyzer.py
+++ b/ML/sentiment_analyzer.py
@@ -1,0 +1,29 @@
+# TextBlob library used for simple sentiment analysis
+from textblob import TextBlob
+
+def analyze_sentiment(text):
+    """
+    Analyze sentiment of input text and return standardized output.
+    """
+
+    blob = TextBlob(text)
+    polarity = blob.sentiment.polarity
+
+    if polarity > 0:
+        sentiment = "positive"
+    elif polarity < 0:
+        sentiment = "negative"
+    else:
+        sentiment = "neutral"
+
+    return {
+        "sentiment": sentiment,
+        "confidence_score": abs(polarity),
+        "text_summary": f"Detected {sentiment} sentiment from the given text."
+    }
+
+
+if __name__ == "__main__":
+    sample = "I really love this product!"
+    result = analyze_sentiment(sample)
+    print(result)

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from .routes import altsense, linksense, geminisense, colorsense, axe_colorsense
+from .routes import altsense, linksense, geminisense, colorsense, axe_colorsense, sentiment
 
 app = FastAPI(
     title="Web Accessibility Analyzer API",
@@ -23,6 +23,7 @@ app.include_router(linksense.router, prefix="/linksense", tags=["LinkSense Analy
 app.include_router(geminisense.router, prefix="/geminisense", tags=["GeminiSense Analysis"])
 # app.include_router(colorsense.router, prefix="/colorsense-old", tags=["ColorSense Analysis - Deprecated"])  # Old implementation
 app.include_router(axe_colorsense.router, tags=["ColorSense Analysis"]) 
+app.include_router(sentiment.router, prefix="/sentiment", tags=["Sentiment Analysis"])
 
 @app.get("/")
 async def root():

--- a/app/routes/sentiment.py
+++ b/app/routes/sentiment.py
@@ -1,0 +1,18 @@
+# Sentiment analysis endpoint using TextBlob
+# This exposes the sentiment analyzer module through the API
+from fastapi import APIRouter
+from pydantic import BaseModel
+from ML.sentiment_analyzer import analyze_sentiment
+
+router = APIRouter()
+
+class SentimentRequest(BaseModel):
+    text: str
+
+@router.post("/analyze")
+def analyze_text(data: SentimentRequest):
+    """
+    Analyze sentiment of the given text.
+    """
+    result = analyze_sentiment(data.text)
+    return result

--- a/app/routes/sentiment.py
+++ b/app/routes/sentiment.py
@@ -8,11 +8,31 @@ router = APIRouter()
 
 class SentimentRequest(BaseModel):
     text: str
+class BatchSentimentRequest(BaseModel):
+    texts: list[str]
 
-@router.post("/analyze")
+@router.post(
+    "/analyze",
+    summary="Analyze sentiment of text",
+    description="Takes a text input and returns sentiment, confidence score, and a short summary."
+)
 def analyze_text(data: SentimentRequest):
-    """
-    Analyze sentiment of the given text.
-    """
+    if not data.text.strip():
+        return {"error": "Text input cannot be empty"}
+
     result = analyze_sentiment(data.text)
     return result
+
+
+@router.post("/batch")
+def analyze_batch(data: BatchSentimentRequest):
+    """
+    Analyze sentiment for multiple texts.
+    """
+
+    results = []
+
+    for text in data.texts:
+        result = analyze_sentiment(text)
+        results.append(result)
+    return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,3 +62,4 @@ wsproto==1.2.0
 transformers>=4.25.0
 torch>=2.0.0
 pillow>=9.0.0
+textblob==0.19.0


### PR DESCRIPTION
This PR adds sentiment analysis endpoints to the API.

It connects the existing sentiment analyzer module with FastAPI and exposes it through API routes.

Endpoints added:

POST /sentiment/analyze
Analyze sentiment of a single text.

POST /sentiment/batch
Analyze sentiment for multiple texts in one request.

The batch endpoint allows users to send multiple texts and receive sentiment results for each of them.